### PR TITLE
recipes/switchdev/l3-000-minimal.py: add ipv6 route before ping

### DIFF
--- a/recipes/switchdev/l3-000-minimal.py
+++ b/recipes/switchdev/l3-000-minimal.py
@@ -21,6 +21,9 @@ def test_ip(major, minor, prefix=[24,64]):
 def ipv4(test_ip):
     return test_ip[0]
 
+def ipv6(test_ip):
+    return test_ip[1]
+
 def do_task(ctl, hosts, ifaces, aliases):
     m1, m2, sw = hosts
     m1_if1, m2_if1, sw_if1, sw_if2 = ifaces
@@ -33,6 +36,10 @@ def do_task(ctl, hosts, ifaces, aliases):
 
     m1_if1.add_nhs_route(ipv4(test_ip(2,0)), [ipv4(test_ip(1,2,[]))]);
     m2_if1.add_nhs_route(ipv4(test_ip(1,0)), [ipv4(test_ip(2,2,[]))]);
+
+    m1_if1.add_nhs_route(ipv6(test_ip(2,0)), [ipv6(test_ip(1,2,[]))], True);
+    m2_if1.add_nhs_route(ipv6(test_ip(1,0)), [ipv6(test_ip(2,2,[]))], True);
+
 
     sleep(30)
 


### PR DESCRIPTION
Signed-off-by: liali <liali@redhat.com>

Hi pirko,

I am liliang from redhat, i am testing switchdev now.
I found a issue in recipes/switchdev/l3-000-minimal.py.
It should add ipv6 route before ping, or it will fail.