### PR TITLE
[WIP] InterfaceManager: fix imports

### DIFF
--- a/lnst/Slave/InterfaceManager.py
+++ b/lnst/Slave/InterfaceManager.py
@@ -24,24 +24,18 @@ from lnst.Common.ExecCmd import exec_cmd
 from lnst.Common.ConnectionHandler import recv_data
 from lnst.Slave.DevlinkManager import DevlinkManager
 from pyroute2 import IPRSocket
-from pyroute2.netlink.rtnl import RTNLGRP_IPV4_IFADDR
-from pyroute2.netlink.rtnl import RTNLGRP_IPV6_IFADDR
-from pyroute2.netlink.rtnl import RTNLGRP_LINK
-try:
-    from pyroute2.netlink.iproute import RTM_NEWLINK
-    from pyroute2.netlink.iproute import RTM_DELLINK
-    from pyroute2.netlink.iproute import RTM_NEWADDR
-    from pyroute2.netlink.iproute import RTM_DELADDR
-except ImportError:
-    from pyroute2.iproute import RTM_NEWLINK
-    from pyroute2.iproute import RTM_DELLINK
-    from pyroute2.iproute import RTM_NEWADDR
-    from pyroute2.iproute import RTM_DELADDR
+from pyroute2.netlink.rtnl import RTMGRP_IPV4_IFADDR
+from pyroute2.netlink.rtnl import RTMGRP_IPV6_IFADDR
+from pyroute2.netlink.rtnl import RTMGRP_LINK
+from pyroute2.netlink.rtnl import RTM_NEWLINK
+from pyroute2.netlink.rtnl import RTM_DELLINK
+from pyroute2.netlink.rtnl import RTM_NEWADDR
+from pyroute2.netlink.rtnl import RTM_DELADDR
 
 class IfMgrError(Exception):
     pass
 
-NL_GROUPS = RTNLGRP_IPV4_IFADDR | RTNLGRP_IPV6_IFADDR | RTNLGRP_LINK
+NL_GROUPS = RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR | RTMGRP_LINK
 
 class InterfaceManager(object):
     def __init__(self, server_handler):


### PR DESCRIPTION
These were moved a long time ago. Used in pyroute2 from 0.2.15::

    # pyroute2.netlink.rtnl
    RTM_NEWLINK
    RTM_DELLINK
    RTM_NEWADDR
    RTM_DELADDR

These were *renamed* in the kernel. Used in pyroute2 from 0.5.1::

    # pyroute2.netlink.rtnl
    RTMGRP_IPV4_IFADDR
    RTMGRP_IPV6_IFADDR
    RTMGRP_LINK

The details about the multicast groups see the pyroute2 git log:
 * c435651eca552db32af15c552c1b9a3a5aa8e350
 * 39fa987f9d6876966dad5be1b911e54f597dc8b3